### PR TITLE
Release 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ saver.SaveCodeToFile(@class, @"/path/HelloWorld.cs");
 var compiler = new Compiler();
 
 // From string
-var result = await compiler.CompileSourceAsync(@"/path/HelloWorld.dll", code).Result;
+var result = await compiler.CompileSourceAsync(@"/path/HelloWorld.dll", generatedCode);
 
 // From file
-var result = await compiler.CompileSourceAsync(@"/path/HelloWorld.dll",  @"/path/HelloWorld.cs").Result;
+var result = await compiler.CompileFilesAsync(@"/path/HelloWorld.dll",  @"/path/HelloWorld.cs");
 ```
 
 ## Missing anything? 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ saver.SaveCodeToFile(@class, @"/path/HelloWorld.cs");
 var compiler = new Compiler();
 
 // From string
-var result = await compiler.CompileSourceAsync(@"/path/HelloWorld.dll", code);
+var result = await compiler.CompileSourceAsync(@"/path/HelloWorld.dll", code).Result;
 
 // From file
-var result = await compiler.CompileSourceAsync(@"/path/HelloWorld.dll",  @"/path/HelloWorld.cs");
+var result = await compiler.CompileSourceAsync(@"/path/HelloWorld.dll",  @"/path/HelloWorld.cs").Result;
 ```
 
 ## Missing anything? 

--- a/Testura.Code.sln
+++ b/Testura.Code.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26014.0
+VisualStudioVersion = 15.0.26020.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testura.Code", "src\Testura.Code\Testura.Code.csproj", "{00B9050D-ECCE-45CE-851C-A88BECB912E8}"
 EndProject

--- a/src/Testura.Code.Tests/Builders/ClassBuilderTests.cs
+++ b/src/Testura.Code.Tests/Builders/ClassBuilderTests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using Testura.Code.Builders;
 using Testura.Code.Models;
+using Testura.Code.Models.Properties;
 
 namespace Testura.Code.Tests.Builders
 {
@@ -44,7 +45,7 @@ namespace Testura.Code.Tests.Builders
         [Test]
         public void Build_WhenGivenProperty_CodeShouldContainProperty()
         {
-            Assert.IsTrue(_classBuilder.WithProperties(new Property("MyProperty", typeof(int), PropertyTypes.GetAndSet)).Build().ToString().Contains("intMyProperty{get;set;}"));
+            Assert.IsTrue(_classBuilder.WithProperties(new AutoProperty("MyProperty", typeof(int), PropertyTypes.GetAndSet)).Build().ToString().Contains("intMyProperty{get;set;}"));
         }
 
         [Test]

--- a/src/Testura.Code.Tests/Generators/Class/PropertyGeneratorTests.cs
+++ b/src/Testura.Code.Tests/Generators/Class/PropertyGeneratorTests.cs
@@ -1,7 +1,12 @@
 ﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using NUnit.Framework;
 using Testura.Code.Generators.Class;
+using Testura.Code.Generators.Common;
 using Testura.Code.Models;
+using Testura.Code.Models.Properties;
+using Testura.Code.Models.References;
+using Testura.Code.Statements;
 using Assert = NUnit.Framework.Assert;
 
 namespace Testura.Code.Tests.Generators.Class
@@ -10,27 +15,58 @@ namespace Testura.Code.Tests.Generators.Class
     class PropertyGeneratorTests
     {
         [Test]
-        public void Create_WhenCreatingPropertyWithOnlyGet_ShouldHaveNoSet()
+        public void Create_WhenCreatingAutoPropertyWithOnlyGet_ShouldHaveNoSet()
         {
-            Assert.AreEqual("intMyProperty{get;}", PropertyGenerator.Create(new Property("MyProperty", typeof(int), PropertyTypes.Get)).ToString());   
+            Assert.AreEqual("intMyProperty{get;}", PropertyGenerator.Create(new AutoProperty("MyProperty", typeof(int), PropertyTypes.Get)).ToString());   
         }
 
         [Test]
-        public void Create_WhenCreatingPropertyWithOnlyGetAndSet_ShouldHaveBothGetAndSet()
+        public void Create_WhenCreatingAutoPropertyWithGetAndSet_ShouldHaveBothGetAndSet()
         {
-            Assert.AreEqual("intMyProperty{get;set;}", PropertyGenerator.Create(new Property("MyProperty", typeof(int), PropertyTypes.GetAndSet)).ToString());
+            Assert.AreEqual("intMyProperty{get;set;}", PropertyGenerator.Create(new AutoProperty("MyProperty", typeof(int), PropertyTypes.GetAndSet)).ToString());
         }
 
         [Test]
-        public void Create_WhenCreatingPropertyWithAttribute_ShouldHaveAttribute()
+        public void Create_WhenCreatingAutoPropertyWithAttribute_ShouldHaveAttribute()
         {
-            Assert.AreEqual("[Test]intMyProperty{get;set;}", PropertyGenerator.Create(new Property("MyProperty", typeof(int), PropertyTypes.GetAndSet, new List<Modifiers>(), new List<Attribute> { new Attribute("Test")})).ToString());
+            Assert.AreEqual("[Test]intMyProperty{get;set;}", PropertyGenerator.Create(new AutoProperty("MyProperty", typeof(int), PropertyTypes.GetAndSet, new List<Modifiers>(), new List<Attribute> { new Attribute("Test")})).ToString());
         }
 
         [Test]
-        public void Create_WhenCreatingPropertyWithModifer_ShouldHaveModifier()
+        public void Create_WhenCreatingAutoPropertyWithModifer_ShouldHaveModifier()
         {
-            Assert.AreEqual("publicstaticintMyProperty{get;set;}", PropertyGenerator.Create(new Property("MyProperty", typeof(int), PropertyTypes.GetAndSet, new List<Modifiers>() { Modifiers.Public, Modifiers.Static })).ToString());
+            Assert.AreEqual("publicstaticintMyProperty{get;set;}", PropertyGenerator.Create(new AutoProperty("MyProperty", typeof(int), PropertyTypes.GetAndSet, new List<Modifiers>() { Modifiers.Public, Modifiers.Static })).ToString());
+        }
+
+        [Test]
+        public void Create_WhenCreatingBodyPropertyWithOnlyGet_ShouldHaveNoSet()
+        {
+            Assert.AreEqual("intMyProperty{get{return1;}}", PropertyGenerator.Create(new BodyProperty("MyProperty", typeof(int), BodyGenerator.Create(Statement.Jump.Return(new ConstantReference(1))))).ToString());
+        }
+
+        [Test]
+        public void Create_WhenCreatingBodyPropertyWithGetAndSet_ShouldHaveBothGetAndSet()
+        {
+            Assert.AreEqual("intMyProperty{get{return1;}}", PropertyGenerator.Create(new BodyProperty("MyProperty", typeof(int), BodyGenerator.Create(Statement.Jump.Return(new ConstantReference(1))))).ToString());
+        }
+
+        [Test]
+        public void Create_WhenCreatingBodyPropertyWithAttribute_ShouldHaveAttribute()
+        {
+            Assert.AreEqual("[Test]intMyProperty{get{return1;}}", PropertyGenerator.Create(new BodyProperty(
+                "MyProperty", 
+                typeof(int),
+                BodyGenerator.Create(Statement.Jump.Return(new ConstantReference(1))), 
+                attributes: new List<Attribute> { new Attribute("Test")})).ToString());
+        }
+        [Test]
+        public void Create_WhenCreatingBodyPropertyWithModifier_ShouldHaveModifier()
+        {
+            Assert.AreEqual("publicvirtualintMyProperty{get{return1;}}", PropertyGenerator.Create(new BodyProperty(
+                "MyProperty", 
+                typeof(int), 
+                BodyGenerator.Create(Statement.Jump.Return(new ConstantReference(1))), 
+                new List<Modifiers> { Modifiers.Public, Modifiers.Virtual })).ToString());
         }
     }
 }

--- a/src/Testura.Code.Tests/Generators/Common/Arguments/ArgumentTypes/ParenthesizedLambdaArgumentTests.cs
+++ b/src/Testura.Code.Tests/Generators/Common/Arguments/ArgumentTypes/ParenthesizedLambdaArgumentTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Framework;
+using Testura.Code.Generators.Common.Arguments.ArgumentTypes;
+using Testura.Code.Models;
+using Testura.Code.Statements;
+
+namespace Testura.Code.Tests.Generators.Common.Arguments.ArgumentTypes
+{
+    [TestFixture]
+    public class ParenthesizedLambdaArgumentTests
+    {
+        [Test]
+        public void GetArgumentSyntax_WhenCreatingEmpty_ShouldGetCorrectCode()
+        {
+            var argument = new ParenthesizedLambdaArgument(Statement.Expression.Invoke("MyMethod").AsExpression());
+            var syntax = argument.GetArgumentSyntax();
+            
+            Assert.IsInstanceOf<ArgumentSyntax>(syntax);
+            Assert.AreEqual("()=>MyMethod()", syntax.ToString());
+        }
+    }
+}

--- a/src/Testura.Code.Tests/Integration/ModelClassTests.cs
+++ b/src/Testura.Code.Tests/Integration/ModelClassTests.cs
@@ -1,11 +1,17 @@
 ﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Testura.Code.Statements;
 using NUnit.Framework;
 using Testura.Code.Builders;
+using Testura.Code.Compilations;
 using Testura.Code.Generators.Class;
 using Testura.Code.Generators.Common;
 using Testura.Code.Models;
+using Testura.Code.Models.Options;
+using Testura.Code.Models.Properties;
 using Testura.Code.Models.References;
+using Testura.Code.Saver;
 
 namespace Testura.Code.Tests.Integration
 {
@@ -19,8 +25,8 @@ namespace Testura.Code.Tests.Integration
             var @class = classBuilder
                 .WithUsings("System")
                 .WithProperties(
-                    PropertyGenerator.Create(new Property("Name", typeof(string), PropertyTypes.GetAndSet, new List<Modifiers> { Modifiers.Public } )), 
-                    PropertyGenerator.Create(new Property("Age", typeof(int), PropertyTypes.GetAndSet, new List<Modifiers> { Modifiers.Public })))
+                    PropertyGenerator.Create(new AutoProperty("Name", typeof(string), PropertyTypes.GetAndSet, new List<Modifiers> { Modifiers.Public } )), 
+                    PropertyGenerator.Create(new AutoProperty("Age", typeof(int), PropertyTypes.GetAndSet, new List<Modifiers> { Modifiers.Public })))
                 .WithConstructor(
                     ConstructorGenerator.Create(
                         "Cat",
@@ -34,6 +40,44 @@ namespace Testura.Code.Tests.Integration
 
             Assert.AreEqual(
                 "usingSystem;namespaceModels{publicclassCat{publicCat(stringname,intage){Name=name;Age=age;}publicstringName{get;set;}publicintAge{get;set;}}}",
+                @class.ToString());
+        }
+
+        [Test]
+        public void Test_CreateModelClassWithBodyProperties()
+        {
+            var classBuilder = new ClassBuilder("Cat", "Models");
+            var @class = classBuilder
+                .WithUsings("System")
+                .WithFields(
+                    new Field("_name", typeof(string), new List<Modifiers>() { Modifiers.Private}),
+                    new Field("_age", typeof(int), new List<Modifiers>() { Modifiers.Private }))
+                .WithProperties(
+                    PropertyGenerator.Create(
+                        new BodyProperty(
+                            "Name", 
+                            typeof(string), 
+                            BodyGenerator.Create(Statement.Jump.Return(new VariableReference("_name"))), BodyGenerator.Create(Statement.Decleration.Assign("_name", new ValueKeywordReference())),
+                            new List<Modifiers> { Modifiers.Public })),
+                    PropertyGenerator.Create(
+                        new BodyProperty(
+                            "Age",
+                            typeof(int),
+                            BodyGenerator.Create(Statement.Jump.Return(new VariableReference("_age"))), BodyGenerator.Create(Statement.Decleration.Assign("_age", new ValueKeywordReference())),
+                            new List<Modifiers> { Modifiers.Public })))
+                .WithConstructor(
+                    ConstructorGenerator.Create(
+                        "Cat",
+                        BodyGenerator.Create(
+                            Statement.Decleration.Assign("Name", ReferenceGenerator.Create(new VariableReference("name"))),
+                            Statement.Decleration.Assign("Age", ReferenceGenerator.Create(new VariableReference("age")))),
+                        new List<Parameter> { new Parameter("name", typeof(string)), new Parameter("age", typeof(int)) },
+                        new List<Modifiers> { Modifiers.Public }))
+
+                       .Build();
+
+            Assert.AreEqual(
+                "usingSystem;namespaceModels{publicclassCat{privatestring_name;privateint_age;publicCat(stringname,intage){Name=name;Age=age;}publicstringName{get{return_name;}set{_name=value;}}publicintAge{get{return_age;}set{_age=value;}}}}",
                 @class.ToString());
         }
     }

--- a/src/Testura.Code.Tests/Integration/ModelClassTests.cs
+++ b/src/Testura.Code.Tests/Integration/ModelClassTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Microsoft.CodeAnalysis;
 using Testura.Code.Statements;
 using NUnit.Framework;
 using Testura.Code.Builders;
@@ -32,6 +31,7 @@ namespace Testura.Code.Tests.Integration
                         new List<Modifiers> { Modifiers.Public }))
 
                        .Build();
+
             Assert.AreEqual(
                 "usingSystem;namespaceModels{publicclassCat{publicCat(stringname,intage){Name=name;Age=age;}publicstringName{get;set;}publicintAge{get;set;}}}",
                 @class.ToString());

--- a/src/Testura.Code.Tests/Saver/CodeSaverTests.cs
+++ b/src/Testura.Code.Tests/Saver/CodeSaverTests.cs
@@ -1,5 +1,8 @@
-﻿using NUnit.Framework;
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using NUnit.Framework;
 using Testura.Code.Builders;
+using Testura.Code.Models.Options;
 using Testura.Code.Saver;
 
 namespace Testura.Code.Tests.Saver
@@ -22,5 +25,19 @@ namespace Testura.Code.Tests.Saver
             Assert.IsNotNull(code);
             Assert.AreEqual("namespace test\r\n{\r\n    public class TestClass\r\n    {\r\n    }\r\n}", code);
         }
+
+        [Test]
+        public void SaveCodeAsString_WhenSavingCodeAsStringAndOptions_ShouldGetString()
+        {
+            var codeSaver = new CodeSaver(new List<OptionKeyValue> {  new OptionKeyValue(CSharpFormattingOptions.NewLinesForBracesInMethods, false) });
+            var code = codeSaver.SaveCodeAsString(
+                new ClassBuilder("TestClass", "test")
+                    .WithMethods(
+                        new MethodBuilder("MyMethod")
+                        .Build())
+                    .Build());
+            Assert.IsNotNull(code);
+            Assert.AreEqual("namespace test\r\n{\r\n    public class TestClass\r\n    {\r\n        void MyMethod() {\r\n        }\r\n    }\r\n}", code);
+        } 
     }
 }

--- a/src/Testura.Code.Tests/Statements/DeclerationStatementTests.cs
+++ b/src/Testura.Code.Tests/Statements/DeclerationStatementTests.cs
@@ -28,7 +28,7 @@ namespace Testura.Code.Tests.Statements
         [Test]
         public void DeclareAndAssign_WhenCreatingVariableWithoutVar_ShouldUseType()
         {
-            Assert.AreEqual("vartestVariable=1;", statement.DeclareAndAssign("testVariable", 1).ToString());
+            Assert.AreEqual("inttestVariable=1;", statement.DeclareAndAssign("testVariable", 1, false).ToString());
         }
 
         [Test]

--- a/src/Testura.Code.Tests/Statements/SelectionStatementTests.cs
+++ b/src/Testura.Code.Tests/Statements/SelectionStatementTests.cs
@@ -27,7 +27,7 @@ namespace Testura.Code.Tests.Statements
         [Test]
         public void If_WhenCreatingAnIfWithEqualAndExpressionStatement_ShouldGenerateCorrectIfStatementWithoutBraces()
         {
-            Assert.AreEqual("if(2==3)MyMethod()",
+            Assert.AreEqual("if(2==3)MyMethod();",
                 conditional.If(new ValueArgument(2), new ValueArgument(3), ConditionalStatements.Equal, Statement.Expression.Invoke("MyMethod").AsStatement()).ToString());
         }
 

--- a/src/Testura.Code.Tests/Statements/SelectionStatementTests.cs
+++ b/src/Testura.Code.Tests/Statements/SelectionStatementTests.cs
@@ -25,6 +25,13 @@ namespace Testura.Code.Tests.Statements
         }
 
         [Test]
+        public void If_WhenCreatingAnIfWithEqualAndExpressionStatement_ShouldGenerateCorrectIfStatementWithoutBraces()
+        {
+            Assert.AreEqual("if(2==3)MyMethod()",
+                conditional.If(new ValueArgument(2), new ValueArgument(3), ConditionalStatements.Equal, Statement.Expression.Invoke("MyMethod").AsStatement()).ToString());
+        }
+
+        [Test]
         public void If_WhenCreatingAnIfWithNotEqual_ShouldGenerateCorrectIfStatement()
         {
             Assert.AreEqual("if(2!=3){}",

--- a/src/Testura.Code.Tests/Testura.Code.Tests.csproj
+++ b/src/Testura.Code.Tests/Testura.Code.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Generators\Common\Arguments\ArgumentTypes\ClassInitializationArgumentTests.cs" />
     <Compile Include="Generators\Common\Arguments\ArgumentTypes\DictionaryArgumentTests.cs" />
     <Compile Include="Generators\Common\Arguments\ArgumentTypes\InvocationArgumentTests.cs" />
+    <Compile Include="Generators\Common\Arguments\ArgumentTypes\ParenthesizedLambdaArgumentTests.cs" />
     <Compile Include="Generators\Common\Arguments\ArgumentTypes\ReferenceArgumentTests.cs" />
     <Compile Include="Generators\Common\Arguments\ArgumentTypes\TypeOfArgumentTests.cs" />
     <Compile Include="Generators\Common\Arguments\ArgumentTypes\ValueArgumentTests.cs" />

--- a/src/Testura.Code.Tests/Testura.Code.Tests.csproj
+++ b/src/Testura.Code.Tests/Testura.Code.Tests.csproj
@@ -44,6 +44,15 @@
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.1.0.5-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
@@ -56,6 +65,21 @@
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Convention, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Hosting, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Runtime, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.TypedParts, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Testura.Code.Tests/packages.config
+++ b/src/Testura.Code.Tests/packages.config
@@ -3,6 +3,9 @@
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="MSTest.TestAdapter" version="1.1.4-preview" targetFramework="net452" />
   <package id="MSTest.TestFramework" version="1.0.5-preview" targetFramework="net452" />
   <package id="NUnit" version="3.5.0" targetFramework="net452" />

--- a/src/Testura.Code/Builders/ClassBuilder.cs
+++ b/src/Testura.Code/Builders/ClassBuilder.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Testura.Code.Generators.Class;
 using Testura.Code.Generators.Common;
 using Testura.Code.Models;
+using Testura.Code.Models.Properties;
 using Attribute = Testura.Code.Models.Attribute;
 
 namespace Testura.Code.Builders

--- a/src/Testura.Code/Generators/Class/PropertyGenerator.cs
+++ b/src/Testura.Code/Generators/Class/PropertyGenerator.cs
@@ -3,7 +3,8 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Testura.Code.Generators.Common;
-using Testura.Code.Models;
+using Testura.Code.Models.Properties;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Testura.Code.Generators.Class
 {
@@ -21,14 +22,18 @@ namespace Testura.Code.Generators.Class
                 throw new ArgumentNullException(nameof(property));
             }
 
-            var propertyDecleration = SyntaxFactory.PropertyDeclaration(
-                TypeGenerator.Create(property.Type), SyntaxFactory.Identifier(property.Name))
-                .AddAccessorListAccessors(SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).
-                    WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
-            if (property.PropertyType == PropertyTypes.GetAndSet)
+            PropertyDeclarationSyntax propertyDecleration;
+            if (property is AutoProperty)
             {
-                propertyDecleration = propertyDecleration.AddAccessorListAccessors(SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration).
-                     WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+                propertyDecleration = CreateAutoProperty((AutoProperty)property);
+            }
+            else if (property is BodyProperty)
+            {
+                propertyDecleration = CreateBodyProperty((BodyProperty)property);
+            }
+            else
+            {
+                throw new ArgumentException($"Unkown property type: {property.Type}, could not generate code.");
             }
 
             if (property.Modifiers != null)
@@ -39,6 +44,37 @@ namespace Testura.Code.Generators.Class
             if (property.Attributes != null)
             {
                 propertyDecleration = propertyDecleration.WithAttributeLists(AttributeGenerator.Create(property.Attributes.ToArray()));
+            }
+
+            return propertyDecleration;
+        }
+
+        private static PropertyDeclarationSyntax CreateAutoProperty(AutoProperty property)
+        {
+            var propertyDecleration = PropertyDeclaration(
+                TypeGenerator.Create(property.Type), Identifier(property.Name))
+                .AddAccessorListAccessors(AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).
+                    WithSemicolonToken(Token(SyntaxKind.SemicolonToken)));
+            if (property.PropertyType == PropertyTypes.GetAndSet)
+            {
+                propertyDecleration = propertyDecleration.AddAccessorListAccessors(AccessorDeclaration(SyntaxKind.SetAccessorDeclaration).
+                     WithSemicolonToken(Token(SyntaxKind.SemicolonToken)));
+            }
+
+            return propertyDecleration;
+        }
+
+        private static PropertyDeclarationSyntax CreateBodyProperty(BodyProperty property)
+        {
+            var propertyDecleration = PropertyDeclaration(
+                    TypeGenerator.Create(property.Type), Identifier(property.Name))
+                .AddAccessorListAccessors(
+                    AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithBody(property.GetBody));
+            if (property.SetBody != null)
+            {
+                propertyDecleration =
+                    propertyDecleration.AddAccessorListAccessors(
+                        AccessorDeclaration(SyntaxKind.SetAccessorDeclaration).WithBody(property.SetBody));
             }
 
             return propertyDecleration;

--- a/src/Testura.Code/Models/Options/OptionKeyValue.cs
+++ b/src/Testura.Code/Models/Options/OptionKeyValue.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.CodeAnalysis.Options;
+
+namespace Testura.Code.Models.Options
+{
+    public class OptionKeyValue
+    {
+        public OptionKeyValue(Option<bool> formattingOption, bool value)
+        {
+            FormattingOption = formattingOption;
+            Value = value;
+        }
+
+        public Option<bool> FormattingOption { get; set; }
+
+        public bool Value { get; set; }
+    }
+}

--- a/src/Testura.Code/Models/Properties/AutoProperty.cs
+++ b/src/Testura.Code/Models/Properties/AutoProperty.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Testura.Code.Models.Properties
+{
+    public class AutoProperty : Property
+    {
+        public AutoProperty(
+            string name,
+            Type type,
+            PropertyTypes propertyType,
+            IEnumerable<Code.Modifiers> modifiers = null,
+            IEnumerable<Attribute> attributes = null)
+            : base(name, type, modifiers, attributes)
+        {
+            PropertyType = propertyType;
+        }
+
+        /// <summary>
+        /// Gets or sets if the property is a get or set.
+        /// </summary>
+        public PropertyTypes PropertyType { get; set; }
+    }
+}

--- a/src/Testura.Code/Models/Properties/BodyProperty.cs
+++ b/src/Testura.Code/Models/Properties/BodyProperty.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Testura.Code.Models.Properties
+{
+    public class BodyProperty : Property
+    {
+        public BodyProperty(string name, Type type, BlockSyntax getBody, BlockSyntax setBody, IEnumerable<Modifiers> modifiers = null, IEnumerable<Attribute> attributes = null)
+            : base(name, type, modifiers, attributes)
+        {
+            if (getBody == null)
+            {
+                throw new ArgumentNullException(nameof(getBody));
+            }
+
+            GetBody = getBody;
+            SetBody = setBody;
+        }
+
+        public BodyProperty(string name, Type type, BlockSyntax getBody, IEnumerable<Modifiers> modifiers = null, IEnumerable<Attribute> attributes = null)
+            : this(name, type, getBody, null, modifiers, attributes)
+        {
+        }
+
+        public BlockSyntax GetBody { get; }
+
+        public BlockSyntax SetBody { get; }
+    }
+}

--- a/src/Testura.Code/Models/Properties/Property.cs
+++ b/src/Testura.Code/Models/Properties/Property.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Testura.Code.Models
+namespace Testura.Code.Models.Properties
 {
-    public class Property
+    public abstract class Property
     {
-        public Property(
+        protected Property(
             string name,
             Type type,
-            PropertyTypes propertyType,
             IEnumerable<Code.Modifiers> modifiers = null,
             IEnumerable<Attribute> attributes = null)
         {
@@ -24,7 +23,6 @@ namespace Testura.Code.Models
 
             Name = name;
             Type = type;
-            PropertyType = propertyType;
             Modifiers = modifiers;
             Attributes = attributes;
         }
@@ -38,11 +36,6 @@ namespace Testura.Code.Models
         /// Gets or sets the type of the property
         /// </summary>
         public Type Type { get; set; }
-
-        /// <summary>
-        /// Gets or sets if the property is a get or set.
-        /// </summary>
-        public PropertyTypes PropertyType { get; set; }
 
         /// <summary>
         /// Gets or sets the modifiers of the property

--- a/src/Testura.Code/Models/References/ValueKeywordReference.cs
+++ b/src/Testura.Code/Models/References/ValueKeywordReference.cs
@@ -1,0 +1,15 @@
+﻿namespace Testura.Code.Models.References
+{
+    public class ValueKeywordReference : VariableReference
+    {
+        public ValueKeywordReference()
+            : base("value")
+        {
+        }
+
+        protected ValueKeywordReference(MemberReference member)
+            : base("value", member)
+        {
+        }
+    }
+}

--- a/src/Testura.Code/Properties/AssemblyInfo.cs
+++ b/src/Testura.Code/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.2.0.0")]

--- a/src/Testura.Code/Saver/CodeSaver.cs
+++ b/src/Testura.Code/Saver/CodeSaver.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.CodeAnalysis;
@@ -12,7 +11,7 @@ namespace Testura.Code.Saver
 {
     public class CodeSaver : ICodeSaver
     {
-        private IList<OptionKeyValue> _options;
+        private readonly IList<OptionKeyValue> _options;
 
         public CodeSaver()
         {

--- a/src/Testura.Code/Statements/DeclerationStatement.cs
+++ b/src/Testura.Code/Statements/DeclerationStatement.cs
@@ -26,7 +26,7 @@ namespace Testura.Code.Statements
                 throw new ArgumentException("Value cannot be null or empty.", nameof(name));
             }
 
-            return LocalDeclarationStatement(VariableDeclaration(IdentifierName(useVarKeyword ? "var" : typeof(T).Name))
+            return LocalDeclarationStatement(VariableDeclaration(useVarKeyword ? IdentifierName("var") : TypeGenerator.Create(typeof(T)))
                 .WithVariables(SingletonSeparatedList(VariableDeclarator(Identifier(name))
                     .WithInitializer(EqualsValueClauseFactory.GetEqualsValueClause(value).WithEqualsToken(Token(SyntaxKind.EqualsToken))))));
         }

--- a/src/Testura.Code/Statements/DeclerationStatement.cs
+++ b/src/Testura.Code/Statements/DeclerationStatement.cs
@@ -50,7 +50,7 @@ namespace Testura.Code.Statements
                 throw new ArgumentNullException(nameof(value));
             }
 
-            return LocalDeclarationStatement(VariableDeclaration(IdentifierName(useVarKeyword ? "var" : typeof(string).Name))
+            return LocalDeclarationStatement(VariableDeclaration(useVarKeyword ? IdentifierName("var") : TypeGenerator.Create(typeof(string)))
                 .WithVariables(SingletonSeparatedList(VariableDeclarator(Identifier(name))
                     .WithInitializer(EqualsValueClauseFactory.GetEqualsValueClause($@"""{value}""").WithEqualsToken(Token(SyntaxKind.EqualsToken))))));
         }
@@ -80,7 +80,7 @@ namespace Testura.Code.Statements
                 throw new ArgumentNullException(nameof(reference));
             }
 
-            return LocalDeclarationStatement(VariableDeclaration(IdentifierName(useVarKeyword ? "var" : type.Name))
+            return LocalDeclarationStatement(VariableDeclaration(useVarKeyword ? IdentifierName("var") : TypeGenerator.Create(type))
                 .WithVariables(SingletonSeparatedList(VariableDeclarator(Identifier(name))
                     .WithInitializer(EqualsValueClauseFactory.GetEqualsValueClause(reference).WithEqualsToken(Token(SyntaxKind.EqualsToken))))));
         }

--- a/src/Testura.Code/Statements/SelectionStatement.cs
+++ b/src/Testura.Code/Statements/SelectionStatement.cs
@@ -37,6 +37,35 @@ namespace Testura.Code.Statements
                     block);
         }
 
+        /// <summary>
+        /// Create the statement syntax for a if-conditional with braces 
+        /// </summary>
+        /// <param name="leftArgument">The left argument of the if-statement</param>
+        /// <param name="rightArgument">The right argument of the if-statement</param>
+        /// <param name="conditional">The conditional</param>
+        /// <param name="expressionStatement">Statement in the if</param>
+        /// <returns>The declared statement syntax</returns>
+        public StatementSyntax If(IArgument leftArgument, IArgument rightArgument, ConditionalStatements conditional, ExpressionStatementSyntax expressionStatement)
+        {
+            if (leftArgument == null)
+            {
+                throw new ArgumentNullException(nameof(leftArgument));
+            }
+
+            if (rightArgument == null)
+            {
+                throw new ArgumentNullException(nameof(rightArgument));
+            }
+
+            return
+                IfStatement(
+                    BinaryExpression(
+                        ConditionalToSyntaxKind(conditional),
+                        leftArgument.GetArgumentSyntax().Expression,
+                        rightArgument.GetArgumentSyntax().Expression),
+                    expressionStatement);
+        }
+
         private SyntaxKind ConditionalToSyntaxKind(ConditionalStatements conditional)
         {
             switch (conditional)

--- a/src/Testura.Code/Statements/SelectionStatement.cs
+++ b/src/Testura.Code/Statements/SelectionStatement.cs
@@ -38,7 +38,7 @@ namespace Testura.Code.Statements
         }
 
         /// <summary>
-        /// Create the statement syntax for a if-conditional with braces 
+        /// Create the statement syntax for a if-conditional with braces
         /// </summary>
         /// <param name="leftArgument">The left argument of the if-statement</param>
         /// <param name="rightArgument">The right argument of the if-statement</param>

--- a/src/Testura.Code/Testura.Code.csproj
+++ b/src/Testura.Code/Testura.Code.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Models\Attribute.cs" />
     <Compile Include="Models\Field.cs" />
     <Compile Include="Models\Invocation.cs" />
+    <Compile Include="Models\Options\OptionKeyValue.cs" />
     <Compile Include="Models\Parameter.cs" />
     <Compile Include="Generators\Class\PropertyGenerator.cs" />
     <Compile Include="Generators\Common\ReferenceGenerator.cs" />

--- a/src/Testura.Code/Testura.Code.csproj
+++ b/src/Testura.Code/Testura.Code.csproj
@@ -108,11 +108,14 @@
     <Compile Include="Generators\Class\PropertyGenerator.cs" />
     <Compile Include="Generators\Common\ReferenceGenerator.cs" />
     <Compile Include="Builders\MethodBuilder.cs" />
-    <Compile Include="Models\Property.cs" />
+    <Compile Include="Models\Properties\AutoProperty.cs" />
+    <Compile Include="Models\Properties\BodyProperty.cs" />
+    <Compile Include="Models\Properties\Property.cs" />
     <Compile Include="Models\References\ConstantReference.cs" />
     <Compile Include="Models\References\MemberReference.cs" />
     <Compile Include="Models\References\MethodReference.cs" />
     <Compile Include="Models\References\NullReference.cs" />
+    <Compile Include="Models\References\ValueKeywordReference.cs" />
     <Compile Include="Models\References\VariableReference.cs" />
     <Compile Include="Compilations\Compiler.cs" />
     <Compile Include="Compilations\CompileResult.cs" />
@@ -141,5 +144,6 @@
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
	- Split the property class in to three classes 
		- A base abstract class 
		- A AutoProperty class for auto property
		- A BodyProperty class for properties with body/blocks.
	- A new reference class for the "value" keyword
	- Code saver now takes a list of options (CSharpFormattingOptions) for better flexibility when generating code.
	- SelectionStatement class now have a new a new overload for the for-method where we take an expression statement instead of body. 
	- Fixed bug with type name when delclare new variables