### PR TITLE
Add ObjectInitializationArgument feature

### DIFF
--- a/src/Testura.Code.Tests/Generators/Common/Arguments/ArgumentTypes/ObjectInitializationArgumentTests.cs
+++ b/src/Testura.Code.Tests/Generators/Common/Arguments/ArgumentTypes/ObjectInitializationArgumentTests.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Framework;
+using Testura.Code.Generators.Common.Arguments.ArgumentTypes;
+using Testura.Code.Models.Types;
+
+namespace Testura.Code.Tests.Generators.Common.Arguments.ArgumentTypes
+{
+    [TestFixture]
+    public class ObjectInitializationArgumentTests
+    {
+        [Test]
+        public void GetArgumentSyntax_WhenInitializeObject_ShouldGetCorrectCode()
+        {
+            var argument = new ObjectInitializationArgument(
+                CustomType.Create("CustomClass"),
+                new Dictionary<string, IArgument> { ["Property"] = new ValueArgument("hello") });
+
+            var syntax = argument.GetArgumentSyntax();
+
+            Assert.IsInstanceOf<ArgumentSyntax>(syntax);
+            Assert.AreEqual("newCustomClass{Property=\"hello\"}", syntax.ToString());
+        }
+
+        [Test]
+        public void GetArgumentSyntax_WhenInitializeObjectWithVariable_ShouldGetCorrectCode()
+        {
+            var argument = new ObjectInitializationArgument(
+                CustomType.Create("CustomClass"),
+                new Dictionary<string, IArgument>
+                    {
+                        ["Property"] = new ValueArgument("hello"),
+                        ["AnotherProperty"] = new VariableArgument("variable")
+                    });
+
+            var syntax = argument.GetArgumentSyntax();
+
+            Assert.IsInstanceOf<ArgumentSyntax>(syntax);
+            Assert.AreEqual("newCustomClass{Property=\"hello\",AnotherProperty=variable}", syntax.ToString());
+        }
+
+        [Test]
+        public void GetArgumentSyntax_WhenInitializeObjectWithDictionary_ShouldGetCorrectCode()
+        {
+            var argument = new ObjectInitializationArgument(
+                CustomType.Create("CustomClass"),
+                new Dictionary<string, IArgument>
+                    {
+                        ["PropertyWithDictionaryType"] =
+                        new DictionaryInitializationArgument<int, int>(
+                            new Dictionary<int, IArgument>
+                                {
+                                    [1] = new ValueArgument(2)
+                                })
+                    });
+
+            var syntax = argument.GetArgumentSyntax();
+
+            Assert.IsInstanceOf<ArgumentSyntax>(syntax);
+            Assert.AreEqual("newCustomClass{PropertyWithDictionaryType=newDictionary<int,int>{[1]=2}}", syntax.ToString());
+        }
+
+        [Test]
+        public void GetArgumentSyntax_WhenInitializeObjectWithAnotherObjectInitialize_ShouldGetCorrectCode()
+        {
+            var argument = new ObjectInitializationArgument(
+                CustomType.Create("CustomClass"),
+                new Dictionary<string, IArgument>
+                    {
+                        ["CustomPropertyType"] = new ObjectInitializationArgument(
+                            CustomType.Create("CustomPropertyType"),
+                            new Dictionary<string, IArgument>
+                                {
+                                    ["Property"] =
+                                    new ValueArgument(
+                                        "hello")
+                                })
+                    });
+
+            var syntax = argument.GetArgumentSyntax();
+
+            Assert.IsInstanceOf<ArgumentSyntax>(syntax);
+            Assert.AreEqual("newCustomClass{CustomPropertyType=newCustomPropertyType{Property=\"hello\"}}", syntax.ToString());
+        }
+    }
+}

--- a/src/Testura.Code.Tests/Testura.Code.Tests.csproj
+++ b/src/Testura.Code.Tests/Testura.Code.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Generators\Class\ConstructorGeneratorTests.cs" />
     <Compile Include="Generators\Common\Arguments\ArgumentsTests.cs" />
     <Compile Include="Generators\Common\Arguments\ArgumentTypes\ArrayInitializeArgumentTests.cs" />
+    <Compile Include="Generators\Common\Arguments\ArgumentTypes\ObjectInitializationArgumentTests.cs" />
     <Compile Include="Generators\Common\Arguments\ArgumentTypes\ClassInitializationArgumentTests.cs" />
     <Compile Include="Generators\Common\Arguments\ArgumentTypes\DictionaryArgumentTests.cs" />
     <Compile Include="Generators\Common\Arguments\ArgumentTypes\InvocationArgumentTests.cs" />

--- a/src/Testura.Code/Generators/Common/Arguments/ArgumentTypes/ObjectInitializationArgument.cs
+++ b/src/Testura.Code/Generators/Common/Arguments/ArgumentTypes/ObjectInitializationArgument.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+#pragma warning disable 1591
+
+namespace Testura.Code.Generators.Common.Arguments.ArgumentTypes
+{
+    /// <summary>
+    /// Provides the functionality to generate a object initialization. Example of generated code: <c>(new MyClass())</c>
+    /// </summary>
+    public class ObjectInitializationArgument : Argument
+    {
+        private readonly Type type;
+
+        private readonly Dictionary<string, IArgument> _dictionary;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObjectInitializationArgument"/> class.
+        /// </summary>
+        /// <param name="type">Type of the object</param>
+        /// <param name="dictionary">Properties used for object initialization</param>
+        public ObjectInitializationArgument(Type type, IDictionary<string, IArgument> dictionary)
+        {
+            this.type = type;
+            this._dictionary = new Dictionary<string, IArgument>(dictionary);
+        }
+
+        protected override ArgumentSyntax CreateArgumentSyntax()
+        {
+            var syntaxNodeOrTokens = new List<SyntaxNodeOrToken>();
+            foreach (var dictionaryValue in _dictionary)
+            {
+                syntaxNodeOrTokens.Add(
+                    AssignmentExpression(
+                        SyntaxKind.SimpleAssignmentExpression,
+                        IdentifierName(dictionaryValue.Key),
+                        dictionaryValue.Value.GetArgumentSyntax().Expression));
+
+                syntaxNodeOrTokens.Add(Token(SyntaxKind.CommaToken));
+            }
+
+            if (syntaxNodeOrTokens.Any())
+            {
+                syntaxNodeOrTokens.RemoveAt(syntaxNodeOrTokens.Count - 1);
+            }
+
+            return Argument(
+                ObjectCreationExpression(TypeGenerator.Create(type)).WithInitializer(
+                    InitializerExpression(
+                        SyntaxKind.ObjectInitializerExpression,
+                        SeparatedList<ExpressionSyntax>(syntaxNodeOrTokens.ToArray()))));
+        }
+    }
+}

--- a/src/Testura.Code/Testura.Code.csproj
+++ b/src/Testura.Code/Testura.Code.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Extensions\Naming\TypeNamingExtensions.cs" />
     <Compile Include="Generators\Common\Arguments\ArgumentTypes\Argument.cs" />
     <Compile Include="Generators\Common\Arguments\ArgumentTypes\LambdaArgument.cs" />
+    <Compile Include="Generators\Common\Arguments\ArgumentTypes\ObjectInitializationArgument.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Util\AppDomains\AppDomainCodeGenerator.cs" />
     <Compile Include="Util\AppDomains\Proxies\ActionCodeGeneratorProxy.cs" />


### PR DESCRIPTION
Solves issue #27 

Usage:
```csharp
var argument = new ObjectInitializationArgument(
   CustomType.Create("CustomClass"),
   new Dictionary<string, IArgument>
   {
      ["Property"] = new ValueArgument("hello"),
      ["AnotherProperty"] = new VariableArgument("variable")
   });
```
and
```csharp
Statement.Expression.Invoke("Method", new List<IArgument> {argument}).AsStatement();

```
