### PR TITLE
a quick route to allow "string?"

### DIFF
--- a/src/Testura.Code.Tests/Compilation/CompilerTests.cs
+++ b/src/Testura.Code.Tests/Compilation/CompilerTests.cs
@@ -6,7 +6,6 @@ using Testura.Code.Builders;
 using Testura.Code.Compilations;
 
 namespace Testura.Code.Tests.Compilation;
-
 [TestFixture]
 public class CompilerTests
 {
@@ -15,7 +14,7 @@ public class CompilerTests
     [OneTimeSetUp]
     public void SetUp()
     {
-        _compiler = new Compiler(null);
+        _compiler = new Compiler(null, @"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\");
     }
 
     [Test]

--- a/src/Testura.Code.Tests/Generators/Common/TypeGeneratorTests.cs
+++ b/src/Testura.Code.Tests/Generators/Common/TypeGeneratorTests.cs
@@ -53,6 +53,13 @@ public class TypeGeneratorTests
         Assert.AreEqual(expected, TypeGenerator.Create(type).ToString());
     }
 
+    [TestCase(typeof(string), "string?")]
+    public void Create_WhenCreatingNullableString_ShouldGenerateCorrectCode(Type type, string expected)
+    {
+        const bool isNullableString = true;
+        Assert.AreEqual(expected, TypeGenerator.Create(type, isNullableString).ToString());
+    }
+
     [Test]
     public void Create_WhenCreatingDateTimeAsNullable_ShouldGenerateCorrectCode()
     {

--- a/src/Testura.Code/Generators/Common/TypeGenerator.cs
+++ b/src/Testura.Code/Generators/Common/TypeGenerator.cs
@@ -16,8 +16,9 @@ public static class TypeGenerator
     /// Create the syntax for a type.
     /// </summary>
     /// <param name="type">The type to create.</param>
+    /// <param name="isNullableString">special case for nullable string</param>
     /// <returns>The declared type syntax.</returns>
-    public static TypeSyntax Create(Type type)
+    public static TypeSyntax Create(Type type, bool isNullableString = false)
     {
         switch (type)
         {
@@ -42,11 +43,11 @@ public static class TypeGenerator
             return CreateGenericType(type);
         }
 
-        var typeSyntax = CheckPredefinedTypes(type);
+        var typeSyntax = CheckPredefinedTypes(type, isNullableString);
         return typeSyntax ?? ParseTypeName(type.Name);
     }
 
-    private static TypeSyntax? CheckPredefinedTypes(Type type)
+    private static TypeSyntax? CheckPredefinedTypes(Type type, bool nullableString = false)
     {
         TypeSyntax typeSyntax = null;
         var isNullable = false;
@@ -89,7 +90,14 @@ public static class TypeGenerator
 
         if (type == typeof(string))
         {
-            typeSyntax = PredefinedType(Token(SyntaxKind.StringKeyword));
+            if (nullableString)
+            {
+                typeSyntax = PredefinedType(Token(default, SyntaxKind.StringKeyword, "string?", "?", default));
+            }
+            else
+            {
+                typeSyntax = PredefinedType(Token(SyntaxKind.StringKeyword));
+            }
         }
 
         if (type == typeof(sbyte))


### PR DESCRIPTION
involved adding a optional param - see below. 

````csharp
// Namespace path to method >>  Testura.Code.Generators.Common.Create

public static TypeSyntax Create(Type type, bool isNullableString = false)
````

then handling it like so:

````csharp
if (type == typeof(string))
{
    if (nullableString)
    {
        typeSyntax = PredefinedType(Token(default, SyntaxKind.StringKeyword, "string?", "?", default));
    }
    else
    {
        typeSyntax = PredefinedType(Token(SyntaxKind.StringKeyword));
    }
}
````