### PR TITLE
Add netstandard2.0 support to allow using Testura.Code within a Roslyn source generator project

### DIFF
--- a/src/Testura.Code.Tests/Testura.Code.Tests.csproj
+++ b/src/Testura.Code.Tests/Testura.Code.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net7</TargetFrameworks>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Testura.Code.Tests/Testura.Code.Tests.csproj
+++ b/src/Testura.Code.Tests/Testura.Code.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0;net7</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net6.0;net7</TargetFrameworks>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Testura.Code/Generators/Common/Arguments/ArgumentTypes/ObjectInitializationArgument.cs
+++ b/src/Testura.Code/Generators/Common/Arguments/ArgumentTypes/ObjectInitializationArgument.cs
@@ -30,8 +30,11 @@ public class ObjectInitializationArgument : Argument
     protected override ArgumentSyntax CreateArgumentSyntax()
     {
         var syntaxNodeOrTokens = new List<SyntaxNodeOrToken>();
-        foreach (var (key, value) in _dictionary)
+        foreach (var pair in _dictionary)
         {
+            var key = pair.Key;
+            var value = pair.Value;
+
             syntaxNodeOrTokens.Add(
                 AssignmentExpression(
                     SyntaxKind.SimpleAssignmentExpression,

--- a/src/Testura.Code/Testura.Code.csproj
+++ b/src/Testura.Code/Testura.Code.csproj
@@ -42,6 +42,10 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
+      <PackageReference Include="PolySharp" Version="1.14.1">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/Testura.Code/Testura.Code.csproj
+++ b/src/Testura.Code/Testura.Code.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net7</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>


### PR DESCRIPTION
I'm working on making some source generators I use in my own projects into it's own project, later to be published on NuGet, and I saw this project while I was cleaning up the code a bit and looking for a way to make my code generation a bit nicer. I decided to try and port this project to the .NET version required for source generators.

- [X] Add `netstandard2.0` target to `Testura.Code` and `Testura.Code.Tests`
- [X] Add `PolySharp` dependency to `Testura.Code` to polyfill features from newer C# versions into `netstandard2.0` builds
    - This is a source generator only dependency, so it should not be a transitive dependency pulled in by projects depending on `Testura.Code`, and the source generator only adds code when targeting newer C# versions with older target frameworks.
 - [X] Fix code that relies on non-polyfilled C# features within `Testura.Code` until the project builds
 - [x] Make test project build
 - [ ] Make sure tests succeed

Will update in comments on my current progress so far on this.